### PR TITLE
Preventing default event on click

### DIFF
--- a/bookmarklet/bookmarklet.coffee
+++ b/bookmarklet/bookmarklet.coffee
@@ -130,8 +130,12 @@ class SubtlePatternsBookmarklet
                 when 37 then @previous()
                 when 39 then @next()
 
-        @el.find(".previous").click => @previous()
-        @el.find(".next").click => @next()
+        @el.find(".previous").click (e) =>
+            e.preventDefault()
+            @previous()
+        @el.find(".next").click (e) =>
+            e.preventDefault()
+            @next()
         @el.find("select").change =>
             @category = @el.find("select").val()
             @curr = 0


### PR DESCRIPTION
It's a little annoying that the page jumps up when you click on the previous or next button
